### PR TITLE
Fix compilation under 2.067

### DIFF
--- a/source/anansi/container/list.d
+++ b/source/anansi/container/list.d
@@ -1,6 +1,6 @@
 module anansi.container.list;
 
-import std.algorithm, std.conv, std.range, std.stdio, std.traits;
+import std.algorithm, std.conv, std.range, std.stdio, std.traits, std.typecons;
 
 /**
  * A doubley-linked list with a deliberately leaky abstraction. This container 

--- a/source/anansi/container/priorityqueue.d
+++ b/source/anansi/container/priorityqueue.d
@@ -4,7 +4,7 @@
  */
  module anansi.container.priorityqueue;
 
- import std.exception, std.functional, std.math, std.range, std.traits;
+ import std.algorithm, std.exception, std.functional, std.math, std.range, std.traits;
 
 /**
  * A priority queue implementation. Items with the highest priority (as defined


### PR DESCRIPTION
dmd 2.067 is released, and there are some errors:

```
../anansi/source/anansi/container/list.d(233): Error: undefined identifier tuple
../anansi/source/anansi/container/priorityqueue.d(23): Error: undefined identifier move, did you mean template save(T)(T[] a)?
../anansi/source/anansi/container/priorityqueue.d(104): Error: undefined identifier swap
../anansi/source/anansi/container/priorityqueue.d(55): Error: undefined identifier move, did you mean template save(T)(T[] a)?
../anansi/source/anansi/container/priorityqueue.d(131): Error: undefined identifier swap
../anansi/source/anansi/container/priorityqueue.d(142): Error: undefined identifier swap
../anansi/source/anansi/algorithms/bfs.d(125): Error: template instance anansi.traits.isQueue!(DijkstraQueue!(AdjacencyList!(VecS, VecS, DirectedS, char, string), real[]), ulong) error instantiating
../anansi/source/anansi/algorithms/dijkstra.d(310): Error: template instance anansi.algorithms.bfs.breadthFirstVisit!(AdjacencyList!(VecS, VecS, DirectedS, char, string), ulong, DijkstraBfsVisitor!(AdjacencyList!(VecS, VecS, DirectedS, char, string), DijkstraQueue!(AdjacencyList!(VecS, VecS, DirectedS, char, string), real[]), NullDijkstraVisitor!(AdjacencyList!(VecS, VecS, DirectedS, char, string)), real[], ulong[], const(real)[EdgeDescriptor]), Colour[], DijkstraQueue!(AdjacencyList!(VecS, VecS, DirectedS, char, string), real[])) error instantiating
../anansi/source/anansi/algorithms/dijkstra.d(268):        instantiated from here: dijkstraShortestPathsNoInit!(AdjacencyList!(VecS, VecS, DirectedS, char, string), ulong, NullDijkstraVisitor!(AdjacencyList!(VecS, VecS, DirectedS, char, string)), Colour[], ulong[], const(real)[EdgeDescriptor], real[])
source/app.d(64):        instantiated from here: dijkstraShortestPaths!(AdjacencyList!(VecS, VecS, DirectedS, char, string), NullDijkstraVisitor!(AdjacencyList!(VecS, VecS, DirectedS, char, string)), ulong, Colour[], ulong[], real[EdgeDescriptor], real[])
```

Part of my application that cause the fails (templates fails only when instantiating):

``` D
    auto colourMap = new Colour[wgraph.graph.vertexCount];
    auto distance = new real[wgraph.graph.vertexCount];
    auto predecessor = new Graph.VertexDescriptor[wgraph.graph.vertexCount];

    dijkstraShortestPaths(wgraph.graph, wgraph.enter, wgraph.weights, predecessor,
        NullDijkstraVisitor!Graph(),
        colourMap,
        distance);
```
